### PR TITLE
Fix Toon reboots

### DIFF
--- a/custom_components/toon_boilerstatus/sensor.py
+++ b/custom_components/toon_boilerstatus/sensor.py
@@ -93,7 +93,7 @@ class ToonBoilerStatusData(object):
 
         try:
             with async_timeout.timeout(5):
-                response = await self._session.get(self._url)
+                response = await self._session.get(self._url, headers={"Accept-Encoding": "identity"})
         except aiohttp.ClientError:
             _LOGGER.error("Cannot poll Toon using url: %s", self._url)
             return


### PR DESCRIPTION
Due to gzip/deflate is acceptable, the Toon WebServer compresses the data ... This results in a lot of temporary files and in a few days it results in reboot of the Toon.